### PR TITLE
Fixed Error When Using OctoberCMS as a SPA (e.g. easySPA plugin)

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -23,7 +23,7 @@ class Plugin extends \System\Classes\PluginBase
     {
         Event::listen('cms.page.beforeRenderPage', function($controller, $page) {
             $twig = $controller->getTwig();
-            $twig->addExtension(new Extension(true));
+            !$twig->hasExtension('nochso\HtmlCompressTwig\Extension') && $twig->addExtension(new Extension(true));
         });
     }
 }


### PR DESCRIPTION
When using OctoberCMS as a SPA (Single Page Application), it changes the page and the html markup for each page using purely ajax.  Because the registration of HtmlCompressTwig is preserved if a page is not reloaded, it throws an error (screenshot below).  

This is a fix for this that adds a condition to check whether HtmlCompressTwig is already registered before trying to add it.

![error_screenshot](https://user-images.githubusercontent.com/2319364/61751101-0d1b4c00-ad5c-11e9-844a-53b752974a5d.png)